### PR TITLE
Update for version 2023.1 compatibility.

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("""Bluetooth Audio is  an NVDA add-on that improves sound quality when working with bluetooth headphones or speakers."""),
 	# version
-	"addon_version" : "1.4",
+	"addon_version" : "1.5",
 	# Author(s)
 	"addon_author" : u"Tony Malykh <anton.malykh@gmail.com>",
 	# URL for the add-on documentation support
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion" : "2019.2.0",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2022.1.0",
+	"addon_lastTestedNVDAVersion" : "2023.1",
 	# Add-on update channel (default is None, denoting stable releases, and for development releases, use "dev"; do not change unless you know what you are doing)
 	"addon_updateChannel" : None,
 }


### PR DESCRIPTION
I've tested this and looked for any breaking API changes that might effect this add-on, and found none. The log hasn't indicated any errors on this add-on, and it appears to be functioning perfectly in NVDA 2023.1.